### PR TITLE
Added more general getLineupCombinations function

### DIFF
--- a/src/browser/stores/dota.js
+++ b/src/browser/stores/dota.js
@@ -48,19 +48,18 @@ const DotaStore = Fluxxor.createStore({
 
     getLineupCombinations(id, heroLength, leagueOrPatch) {
         let _this = this;
+
         let sortedCombinations = new LineupCollection();
         if (leagueOrPatch === "league") {
-            sortedCombinations = this.lineupCollection.getForLeague(id, heroLength)
-                .sort((a, b) => b.count - a.count);    
+            sortedCombinations = this.lineupCollection.getForLeague(id, heroLength);            
         }
         else if (leagueOrPatch === "patch") {
-            sortedCombinations = this.lineupCollection.getForPatch(id, heroLength)
-                .sort((a, b) => b.count - a.count);           
+            sortedCombinations = this.lineupCollection.getForPatch(id, heroLength)         
         }
         else {
             throw new Error('getLineupCombinations called with impromper argument (should have "league" or "patch")');
         }
-
+	sortedCombinations.sort((a, b) => b.count - a.count);    
 
         let sortedCombinationsWithHeroNames = [];
 

--- a/src/browser/stores/dota.js
+++ b/src/browser/stores/dota.js
@@ -46,10 +46,21 @@ const DotaStore = Fluxxor.createStore({
         });
     },
 
-    getLineupCombinationsForLeague(leagueId, heroLength) {
+    getLineupCombinations(id, heroLength, leagueOrPatch) {
         let _this = this;
-        let sortedCombinations = this.lineupCollection.getForLeague(leagueId, heroLength)
-            .sort((a, b) => b.count - a.count);
+        let sortedCombinations = new LineupCollection();
+        if (leagueOrPatch === "league") {
+            sortedCombinations = this.lineupCollection.getForLeague(id, heroLength)
+                .sort((a, b) => b.count - a.count);    
+        }
+        else if (leagueOrPatch === "patch") {
+            sortedCombinations = this.lineupCollection.getForPatch(id, heroLength)
+                .sort((a, b) => b.count - a.count);           
+        }
+        else {
+            throw new Error('getLineupCombinations called with impromper argument (should have "league" or "patch")');
+        }
+
 
         let sortedCombinationsWithHeroNames = [];
 
@@ -69,6 +80,14 @@ const DotaStore = Fluxxor.createStore({
         });
 
         return sortedCombinationsWithHeroNames;
+    },
+
+    getLineupCombinationsForLeague(leagueId, heroLength) {
+        return this.getLineupCombinations(leagueId, heroLength, "league");
+    },
+
+    getLineupCombinationsForPatch(patchId, heroLength) {
+        return this.getLineupCombinations(patchId, heroLength, "patch");
     },
 
     getPatchList() {


### PR DESCRIPTION
For future viewing results by patch support, getLineupCombinationsForLeague now calls a more general function getLineupCombinations that works with both leagues and patches. 